### PR TITLE
Change versioning to v0.9.3 and remove deprecated flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ To start your beacon node, issue the following command:
 ```text
 docker run -it -v $HOME/prysm:/data -p 4000:4000 --name beacon-node \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
-  --datadir=/data \
-  --init-sync-no-verify
+  --datadir=/data
 ```
 
 The beacon node can be halted by either using `Ctrl+c` or with the command:
@@ -128,7 +127,7 @@ docker run -it -v $HOME/prysm:/data -p 4000:4000 --name beacon-node \
 3. To run the beacon node, issue the following command:
 
 ```text
-docker run -it -v c:/prysm/:/data -p 4000:4000 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --init-sync-no-verify --clear-db
+docker run -it -v c:/prysm/:/data -p 4000:4000 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db
 ```
 
 ### Running via Bazel
@@ -177,7 +176,6 @@ Open up two terminal windows. In the first, issue the command:
 
 ```text
 bazel run //beacon-chain -- \
---no-genesis-delay \
 --bootstrap-node= \
 --deposit-contract 0xD775140349E6A5D12524C6ccc3d6A1d4519D4029 \
 --clear-db \

--- a/activating-a-validator.md
+++ b/activating-a-validator.md
@@ -67,27 +67,26 @@ Open a terminal window. Depending on your platform, issue the appropriate comman
 ```text
 docker run -it -v $HOME/prysm/beacon:/data -p 4000:4000 \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
-  --datadir=/data \
-  --init-sync-no-verify
+  --datadir=/data
 ```
 
 #### Starting the beacon node with Docker on WIndows
 
 ```text
-docker run -it -v $HOME/prysm/beacon:/data -p 4000:4000 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --init-sync-no-verify
+docker run -it -v $HOME/prysm/beacon:/data -p 4000:4000 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data
 ```
 
 #### Starting the beacon node with Bazel
 
 ```text
-bazel run //beacon-chain -- --datadir=$HOME/beacon-chain --init-sync-no-verify
+bazel run //beacon-chain -- --datadir=$HOME/beacon-chain
 ```
 
 The beacon node will spin up and immediately begin communicating with the Prysm testnet, outputting data similar to the image below.
 
 ![](.gitbook/assets/9.png)
 
-The process of syncronising may take a while; the incoming block per second capacity is dependent upon the connection strength, network congestion and overall peer count. 
+The process of syncronising may take a while; the incoming block per second capacity is dependent upon the connection strength, network congestion and overall peer count.
 
 ## Starting up the validator client
 

--- a/how-prysm-works/ethereum-2.0-public-api.md
+++ b/how-prysm-works/ethereum-2.0-public-api.md
@@ -6,7 +6,7 @@ description: >-
 
 # Ethereum 2.0 Public API
 
-One of the required components for staking on the Ethereum 2.0 network is the [gRPC](https://grpc.io) server. It is utilised by the client to query the network for a variety of different public data, from the [canonical head block](../glossaries/terminology.md#canonical-head-block) to versioning and assignments. 
+One of the required components for staking on the Ethereum 2.0 network is the [gRPC](https://grpc.io) server. It is utilised by the client to query the network for a variety of different public data, from the [canonical head block](../glossaries/terminology.md#canonical-head-block) to versioning and assignments.
 
 Interacting with the API requires the use of protocol buffers, also known as protobuf. These [protocol buffer](https://developers.google.com/protocol-buffers/) service definitions support both [gRPC](https://grpc.io/) as well as JSON over HTTP.  For information on the functionality of gRPC and protocol buffers more generally, see the [gRPC guide](https://grpc.io/docs/guides/).
 
@@ -16,7 +16,7 @@ Interacting with the API requires the use of protocol buffers, also known as pro
 | :--- | :--- | :--- | :--- |
 | eth | [BeaconChain](https://github.com/prysmaticlabs/ethereumapis/blob/master/eth/v1alpha1/beacon_chain.proto#L36) | v1alpha1 | This service is used to retrieve critical data relevant to the Ethereum 2.0 phase 0 beacon chain, including the most recent head block, current pending deposits, the chain state and more. |
 | eth | [Node](https://github.com/prysmaticlabs/ethereumapis/blob/master/eth/v1alpha1/node.proto#L33) | v1alpha1 | The Node service returns information about the Ethereum node itself, including versioning and general information as well as network sync status and a list of services currently implemented on the node. |
-| eth | [Validator](https://github.com/prysmaticlabs/ethereumapis/blob/master/eth/v1alpha1/validator.proto) | v1alpha\` | This API provides the information a validator needs to retrieve throughout its lifecycle, including recieved assignments from the network, its current index in the state as well as the rewards and penalties that have been applied to it. |
+| eth | [Validator](https://github.com/prysmaticlabs/ethereumapis/blob/master/eth/v1alpha1/validator.proto) | v1alpha1 | This API provides the information a validator needs to retrieve throughout its lifecycle, including recieved assignments from the network, its current index in the state as well as the rewards and penalties that have been applied to it. |
 
 ## Generating client libraries
 
@@ -42,7 +42,7 @@ go get -u github.com/golang/protobuf/protoc-gen-go
 
 The compiler plugin `protoc-gen-go` will be installed in `$GOBIN`, defaulting to `$GOPATH/bin`. It must be in your `$PATH` for `protoc` to locate it.
 
-The compiler can now be run. Note that this command requires a few parameters; namely a source directly, a destination directory and a path to the `.proto` file itself. 
+The compiler can now be run. Note that this command requires a few parameters; namely a source directly, a destination directory and a path to the `.proto` file itself.
 
 ```text
 protoc -I=$SRC_DIR --go_out=$DST_DIR $SRC_DIR/node.proto

--- a/how-prysm-works/validator-clients.md
+++ b/how-prysm-works/validator-clients.md
@@ -12,13 +12,13 @@ As mentioned, validators have two responsibilities: to [propose](../glossaries/t
 
 ## How does it work?
 
-A validator instance is permitted to begin participating in the network once 32 Goerli ETH is locked up in a [validator deposit contract](validator-deposit-contract.md). Validators are tasked with correctly [proposing](../glossaries/terminology.md#propose) or [attesting](../glossaries/terminology.md#attest) to blocks on the beacon chain, and receive either rewards or penalties to the initial deposit based upon their overall performance. 
+A validator instance is permitted to begin participating in the network once 32 ETH is locked up in a [validator deposit contract](validator-deposit-contract.md). Validators are tasked with correctly [proposing](../glossaries/terminology.md#propose) or [attesting](../glossaries/terminology.md#attest) to blocks on the beacon chain, and receive either rewards or penalties to the initial deposit based upon their overall performance.
 
-If validators act against the protocol, their locked up deposit will be cut in a process known as 'slashing'. Validators that are intermittently offline or do not have reliable uptime will gradually lose their deposit, eventually leaking enough to be automatically removed from the network entirely. More on this topic can be found in the [Ethereum 2.0 economics](https://docs.ethhub.io/ethereum-roadmap/ethereum-2.0/eth-2.0-economics/) outline. 
+If validators act against the protocol, their locked up deposit will be cut in a process known as 'slashing'. Validators that are intermittently offline or do not have reliable uptime will gradually lose their deposit, eventually leaking enough to be automatically removed from the network entirely. More on this topic can be found in the [Ethereum 2.0 economics](https://docs.ethhub.io/ethereum-roadmap/ethereum-2.0/eth-2.0-economics/) outline.
 
 ## Validator client functionality
 
-Validators are quite lightweight pieces of software and perform only a small number of tasks, though it is critical that they are performed properly. They run in a single function that effectively summarizes every step of their lifecycle succinctly. 
+Validators are quite lightweight pieces of software and perform only a small number of tasks, though it is critical that they are performed properly. They run in a single function that effectively summarizes every step of their lifecycle succinctly.
 
 In order of operations, the client:
 
@@ -28,21 +28,21 @@ In order of operations, the client:
 4. The validator then has a ticker that works every slot \(6 seconds\). If the slot ticks at the validator's assigned slot, a beacon block is either [proposed](../glossaries/terminology.md#propose) or [attested](../glossaries/terminology.md#attest), depending on assigned role.
 5. This repeats forever until the validator decides to exit the system voluntarily, or is penalized by the system for either acting maliciously or being idle when assigned tasks to perform.
 
-As mentioned, every validator instance represents 32 Goerli ETH being staked in the network. In Prysm, this is currently the default; however, the goal is to implement support for running multiple public keys that correspond to multiple validators in a single runtime, simplifying the process of deploying several nodes for those whom want to stake more funds to help secure the network.
+As mentioned, every validator instance represents 32 ETH being staked in the network. In Prysm, this is currently the default; however, the goal is to implement support for running multiple public keys that correspond to multiple validators in a single runtime, simplifying the process of deploying several nodes for those whom want to stake more funds to help secure the network.
 
 ### Proposing a beacon block
 
 A block proposal must include several items to meet the minimum requirements for verification by the protocol. These steps in chronological order are:
 
-1. Fetch the [canonical head block](../glossaries/terminology.md#canonical-head-block) from the beacon node, uses its root as the parent root of the new block. 
+1. Fetch the [canonical head block](../glossaries/terminology.md#canonical-head-block) from the beacon node, uses its root as the parent root of the new block.
 2. Fetch pending deposits which have not yet been included in the chain.
 3. Fetch [ETH1](../glossaries/terminology.md#eth1) data used to vote on deposit objects.
 4. Fetch pending slashings and [validator](../glossaries/terminology.md#validator) voluntary exits.
 5. Fetch latest fork data from the beacon chain.
 6. generate a randao reveal by [BLS](bls-signature-aggregation-and-cryptography.md) signing the epoch.
 7. Fetch any pending attestations from the beacon node.
-8. Construct the block object by packaging the above items into a block data structure. 
-9. Compute the state root hash, sign the block with the [validator](../glossaries/terminology.md#validator)'s private key. 
+8. Construct the block object by packaging the above items into a block data structure.
+9. Compute the state root hash, sign the block with the [validator](../glossaries/terminology.md#validator)'s private key.
 10. Propose the block by sending it to the beacon node via [gRPC](ethereum-2.0-public-api.md).
 
 ### Attesting to a Beacon Block
@@ -50,8 +50,8 @@ A block proposal must include several items to meet the minimum requirements for
 Attesting to a block is a similar process to proposing, albeit with a few slightly different steps:
 
 1. An attestation data structure is assembled and the validator's assigned shard is fetched.
-2. A request is made to the beacon node for the information required to attest a block. 
+2. A request is made to the beacon node for the information required to attest a block.
 3. An attestation bitfield is constructed using the validator index.
-4. The attestation key is then signed with a validator's secret key. 
+4. The attestation key is then signed with a validator's secret key.
 5. Halfway through the slot duration, the attestation is sent to the beacon node via [gRPC](ethereum-2.0-public-api.md).
 

--- a/introduction/about-our-public-testnet.md
+++ b/introduction/about-our-public-testnet.md
@@ -10,15 +10,15 @@ description: >-
 
 * **The testnet is publicly accessible and NOT a simulation.** We provide a cloud cluster of nodes that participate in consensus, but anyone can join the network and contribute.
 * **The testnet is a single client 'Prysm network'.** Unlike Ethereum 1.0, which has Geth and Parity, this network is entirely Prysm-only.
-* **Staking of Goerli test ETH is included in the network.** Users can utilise the deposit contract, run a validator client, and participate in consensus to earn rewards or penalties. 
+* **Staking of Goerli test ETH is included in the network.** Users can utilise the deposit contract, run a validator client, and participate in consensus to earn rewards or penalties.
 * **Features LibP2P by** [**Protocol Labs**](https://protocol.ai/) for decentralised, peer-to-peer networking of nodes.
-* **Implements v0.4 of the official beacon chain specification** created by the Ethereum Research team \(the latest version is v0.8.3\). 
+* **Implements v0.9.3 of the official beacon chain specification** created by the Ethereum Research team \(the latest version is v0.9.4\).
 
 ## Limitations of this release
 
-* **The network does not include smart contract or EVM-related functionality.** This is a part of Ethereum 2.0 Phase 2. The current testnet is only tasked with managing a registry of [validators](../glossaries/terminology.md#validator), allowing for Casper [Proof-of-Stake](../glossaries/terminology.md#proof-of-stake-pos) and the advancement of the blockchain. 
-* **This is NOT a multi-client network**, though this is the next step most ETH2 teams have in mind. 
-* **The testnet uses different configuration parameters than what we’d see on mainnet;** that is, we support fewer shards, a smaller [validator](../glossaries/terminology.md#validator) count, and different constants for the sake of simplicity. 
-* **The testnet does not contain beacon chain transfers or withdrawals**, as those will come in later iterations and are not critical for showcasing the core functions of the beacon chain. 
+* **The network does not include smart contract or EVM-related functionality.** This is a part of Ethereum 2.0 Phase 2. The current testnet is only tasked with managing a registry of [validators](../glossaries/terminology.md#validator), allowing for Casper [Proof-of-Stake](../glossaries/terminology.md#proof-of-stake-pos) and the advancement of the blockchain.
+* **This is NOT a multi-client network**, though this is the next step most ETH2 teams have in mind.
+* **The testnet uses different configuration parameters than what we’d see on mainnet;** that is, we support fewer shards, a smaller [validator](../glossaries/terminology.md#validator) count, and different constants for the sake of simplicity.
+* **The testnet does not contain beacon chain transfers or withdrawals**, as those will come in later iterations and are not critical for showcasing the core functions of the beacon chain.
 * **The testnet is not optimized for a large amount of validators to join.** That is, we have not yet implemented a super-optimal LMD GHOST [fork-choice rule](../glossaries/terminology.md#fork-choice-rule), among other features, to make the code robust enough for hundreds of thousands of [validators](../glossaries/terminology.md#validator) to join.
 

--- a/introduction/about-our-public-testnet.md
+++ b/introduction/about-our-public-testnet.md
@@ -13,12 +13,12 @@ description: >-
 * **Staking of Goerli test ETH is included in the network.** Users can utilise the deposit contract, run a validator client, and participate in consensus to earn rewards or penalties.
 * **Features LibP2P by** [**Protocol Labs**](https://protocol.ai/) for decentralised, peer-to-peer networking of nodes.
 * **Implements v0.9.3 of the official beacon chain specification** created by the Ethereum Research team \(the latest version is v0.9.4\).
+* **The testnet is using the ETH2 mainnet configuration**, with the only change being validators deposit 3.2 ETH, instead of 32 ETH.
 
 ## Limitations of this release
 
 * **The network does not include smart contract or EVM-related functionality.** This is a part of Ethereum 2.0 Phase 2. The current testnet is only tasked with managing a registry of [validators](../glossaries/terminology.md#validator), allowing for Casper [Proof-of-Stake](../glossaries/terminology.md#proof-of-stake-pos) and the advancement of the blockchain.
 * **This is NOT a multi-client network**, though this is the next step most ETH2 teams have in mind.
 * **The testnet uses different configuration parameters than what we’d see on mainnet;** that is, we support fewer shards, a smaller [validator](../glossaries/terminology.md#validator) count, and different constants for the sake of simplicity.
-* **The testnet does not contain beacon chain transfers or withdrawals**, as those will come in later iterations and are not critical for showcasing the core functions of the beacon chain.
-* **The testnet is not optimized for a large amount of validators to join.** That is, we have not yet implemented a super-optimal LMD GHOST [fork-choice rule](../glossaries/terminology.md#fork-choice-rule), among other features, to make the code robust enough for hundreds of thousands of [validators](../glossaries/terminology.md#validator) to join.
+* **The testnet does not contain voluntary exits or attester/proposer slashings**, as those will come in later iterations and are not critical for showcasing the core functions of the beacon chain.
 


### PR DESCRIPTION
This is a PR for updating all references of version to v0.9.3 and removes all deprecated flags from guides.

If there are any new flags needed that testnet users need to know please let me know :)
