### PR TITLE
updates official Ethereum 2.0 P2P spec's URL

### DIFF
--- a/how-prysm-works/p2p-networking.md
+++ b/how-prysm-works/p2p-networking.md
@@ -12,7 +12,7 @@ As stated, Ethereum 2.0 is a distributed and decentralised peer-to-peer \(P2P\) 
 
 Libp2p is a full featured and highly maintained next-generation library. By implementing an already existing and proven peer-to-peer system into Prysm, the low level functions of networking across nodes are managed both effectively and securely 'out of the box', while simultaneously freeing human resources and allowing development to focus on the higher level functionality of the client.
 
-For more information and current developments, see the [official Ethereum 2.0 P2P specification](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/networking/p2p-interface.md).
+For more information and current developments, see the [official Ethereum 2.0 P2P specification](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md).
 
 
 


### PR DESCRIPTION
- `ethereum/eth2.0-specs` repo was re-arranged, so link to P2P docs is broken, and requires update